### PR TITLE
Support fallback to buffered

### DIFF
--- a/buffered.go
+++ b/buffered.go
@@ -103,19 +103,19 @@ func (r *response) header() http.Header {
 	return h
 }
 
-var _ http.RoundTripper = (*Transport)(nil)
+var _ http.RoundTripper = (*BufferedTransport)(nil)
 
-type Transport struct {
+type BufferedTransport struct {
 	lambda invokeAPIClient
 }
 
-func New(c *lambda.Client) *Transport {
-	return &Transport{
+func NewBufferedTransport(c *lambda.Client) *BufferedTransport {
+	return &BufferedTransport{
 		lambda: c,
 	}
 }
 
-func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+func (t *BufferedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
 
 	// build the request

--- a/buffered_test.go
+++ b/buffered_test.go
@@ -19,7 +19,7 @@ func (m InvokeMock) Invoke(ctx context.Context, params *lambda.InvokeInput, optF
 	return m(ctx, params, optFns...)
 }
 
-func TestTransport(t *testing.T) {
+func TestBufferedTransport(t *testing.T) {
 	transport := &BufferedTransport{
 		lambda: InvokeMock(func(ctx context.Context, params *lambda.InvokeInput, optFns ...func(*lambda.Options)) (*lambda.InvokeOutput, error) {
 			var req request

--- a/buffered_test.go
+++ b/buffered_test.go
@@ -20,7 +20,7 @@ func (m InvokeMock) Invoke(ctx context.Context, params *lambda.InvokeInput, optF
 }
 
 func TestTransport(t *testing.T) {
-	transport := &Transport{
+	transport := &BufferedTransport{
 		lambda: InvokeMock(func(ctx context.Context, params *lambda.InvokeInput, optFns ...func(*lambda.Options)) (*lambda.InvokeOutput, error) {
 			var req request
 			if err := json.Unmarshal(params.Payload, &req); err != nil {

--- a/response_streaming.go
+++ b/response_streaming.go
@@ -26,14 +26,14 @@ type invokeWithResponseStreamOutput struct {
 	StreamGetter streamGetter
 }
 
-var _ http.RoundTripper = (*ResponseStreaming)(nil)
+var _ http.RoundTripper = (*Transport)(nil)
 
-type ResponseStreaming struct {
+type Transport struct {
 	lambda func(ctx context.Context, params *lambda.InvokeWithResponseStreamInput, optFns ...func(*lambda.Options)) (*invokeWithResponseStreamOutput, error)
 }
 
-func NewResponseStreaming(c *lambda.Client) *ResponseStreaming {
-	return &ResponseStreaming{
+func NewTransport(c *lambda.Client) *Transport {
+	return &Transport{
 		lambda: func(ctx context.Context, params *lambda.InvokeWithResponseStreamInput, optFns ...func(*lambda.Options)) (*invokeWithResponseStreamOutput, error) {
 			out, err := c.InvokeWithResponseStream(ctx, params, optFns...)
 			if err != nil {
@@ -44,7 +44,7 @@ func NewResponseStreaming(c *lambda.Client) *ResponseStreaming {
 	}
 }
 
-func (t *ResponseStreaming) RoundTrip(req *http.Request) (*http.Response, error) {
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
 
 	// build the request

--- a/response_streaming.go
+++ b/response_streaming.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
@@ -65,8 +67,17 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	stream := out.StreamGetter.GetStream()
+	mediatype, _, err := mime.ParseMediaType(aws.ToString(out.Output.ResponseStreamContentType))
+	if err != nil {
+		return handleStreamingFallbackBuffered(ctx, stream, req)
+	}
+
+	if mediatype != "application/vnd.awslambda.http-integration-response" {
+		return handleStreamingFallbackBuffered(ctx, stream, req)
+	}
+
+	// handle the http-integration-response
 	resp, buf, err := handleStreamingPrelude(ctx, stream)
 	if err != nil {
 		return nil, err
@@ -160,4 +171,47 @@ func (b *streamingBody) Read(p []byte) (int, error) {
 
 func (b *streamingBody) Close() error {
 	return b.stream.Close()
+}
+
+func handleStreamingFallbackBuffered(ctx context.Context, stream *lambda.InvokeWithResponseStreamEventStream, req *http.Request) (*http.Response, error) {
+	buf := []byte{}
+	defer stream.Close()
+
+LOOP:
+	for {
+		var event types.InvokeWithResponseStreamResponseEvent
+		select {
+		case <-ctx.Done():
+			stream.Close()
+			return nil, ctx.Err()
+		case event = <-stream.Events():
+		}
+
+		switch event := event.(type) {
+		case *types.InvokeWithResponseStreamResponseEventMemberInvokeComplete:
+			break LOOP
+		case *types.InvokeWithResponseStreamResponseEventMemberPayloadChunk:
+			buf = append(buf, event.Value.Payload...)
+		default:
+			return nil, fmt.Errorf("lambtrip: unexpected event type: %T", event)
+		}
+	}
+
+	// build the response
+	var resp response
+	if err := json.Unmarshal(buf, &resp); err != nil {
+		return nil, err
+	}
+
+	return &http.Response{
+		Status:     resp.status(),
+		StatusCode: resp.statusCode(),
+		Proto:      "HTTP/1.0",
+		ProtoMajor: 1,
+		ProtoMinor: 0,
+		Header:     resp.header(),
+		Body:       io.NopCloser(strings.NewReader(resp.Body)),
+		Close:      true,
+		Request:    req,
+	}, nil
 }

--- a/response_streaming_test.go
+++ b/response_streaming_test.go
@@ -51,7 +51,7 @@ func (r *invokeWithResponseStreamResponseEventReader) Err() error {
 	return nil
 }
 
-func TestResponseStreaming(t *testing.T) {
+func TestTransport(t *testing.T) {
 	transport := &Transport{
 		lambda: func(ctx context.Context, params *lambda.InvokeWithResponseStreamInput, optFns ...func(*lambda.Options)) (*invokeWithResponseStreamOutput, error) {
 			return &invokeWithResponseStreamOutput{
@@ -65,6 +65,51 @@ func TestResponseStreaming(t *testing.T) {
 						[]byte(`{}`),
 						{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 						[]byte(`"Hello, world!"`),
+					})
+					return stream
+				}),
+			}, nil
+		},
+	}
+
+	ctx := context.Background()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.com/foo/bar", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.Header.Get("Content-Type") != "application/json" {
+		t.Errorf("resp.Header.Get(%q) = %q, want %q", "Content-Type", resp.Header.Get("Content-Type"), "application/json")
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != `"Hello, world!"` {
+		t.Errorf("body = %q, want %q", body, `"Hello, world!"`)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTransport_FallbackToBuffered(t *testing.T) {
+	transport := &Transport{
+		lambda: func(ctx context.Context, params *lambda.InvokeWithResponseStreamInput, optFns ...func(*lambda.Options)) (*invokeWithResponseStreamOutput, error) {
+			return &invokeWithResponseStreamOutput{
+				Output: &lambda.InvokeWithResponseStreamOutput{
+					StatusCode:                http.StatusOK,
+					ResponseStreamContentType: aws.String("application/vnd.amazon.eventstream"),
+				},
+				StreamGetter: GetStreamMock(func() *lambda.InvokeWithResponseStreamEventStream {
+					stream := lambda.NewInvokeWithResponseStreamEventStream()
+					stream.Reader = newInvokeWithResponseStreamResponseEventReader([][]byte{
+						[]byte(`{"body": "\"Hello, world!\""}`),
 					})
 					return stream
 				}),

--- a/response_streaming_test.go
+++ b/response_streaming_test.go
@@ -52,7 +52,7 @@ func (r *invokeWithResponseStreamResponseEventReader) Err() error {
 }
 
 func TestResponseStreaming(t *testing.T) {
-	transport := &ResponseStreaming{
+	transport := &Transport{
 		lambda: func(ctx context.Context, params *lambda.InvokeWithResponseStreamInput, optFns ...func(*lambda.Options)) (*invokeWithResponseStreamOutput, error) {
 			return &invokeWithResponseStreamOutput{
 				Output: &lambda.InvokeWithResponseStreamOutput{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed `Transport` to `BufferedTransport` for clarity.
- **New Features**
	- Enhanced streaming response functionality to support various content types.
- **Tests**
	- Updated tests to reflect changes in transport and streaming response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->