### PR TITLE
Add support for YAML content type in isBinary function

### DIFF
--- a/buffered.go
+++ b/buffered.go
@@ -249,6 +249,9 @@ func isBinary(contentType string) bool {
 	if strings.EqualFold(mediaType, "application/json") {
 		return false
 	}
+	if strings.EqualFold(mediaType, "application/yaml") {
+		return false
+	}
 	if strings.EqualFold(mediaType, "application/javascript") {
 		return false
 	}
@@ -262,6 +265,9 @@ func isBinary(contentType string) bool {
 	}
 	suffix := mediaType[i:]
 	if strings.EqualFold(suffix, "+json") {
+		return false
+	}
+	if strings.EqualFold(suffix, "+yaml") {
 		return false
 	}
 	if strings.EqualFold(suffix, "+xml") {

--- a/buffered_test.go
+++ b/buffered_test.go
@@ -163,11 +163,17 @@ func TestIsBinary(t *testing.T) {
 		{"text/xml", false},
 		{"application/json", false},
 		{"application/javascript", false},
+		{"application/yaml", false},
 		{"application/xml", false},
 		{"application/foo+json", false},
+		{"application/foo+yaml", false},
 		{"application/foo+xml", false},
 		{"application/foo+xml ; charset=utf8", false},
 		{"application/octet-stream", true},
+		{"image/jpeg", true},
+		{"audio/mpeg", true},
+		{"unknown-content-type", true},
+		{"", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
https://github.com/awslabs/aws-lambda-rust-runtime assume YAML files as text

https://github.com/awslabs/aws-lambda-rust-runtime/blob/4824d24c2d3fe2d3faefee326f84cc52c91814ac/lambda-http/src/response.rs#L626-L655

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced file type detection to correctly identify YAML content types as non-binary, improving compatibility with various content types in file uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->