### PR TITLE
add readme and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,79 @@
 # lambtrip
-AWS Lambda wrapper for http.RoundTripper
+
+The package lambtrip is an adapter that converts APIs implemented in AWS Lambda into `http.RoundTripper`.
+No need to use AWS Lambda Function URLs, AWS Gateway, ALB, etc.
+
+## Synopsis
+
+Here is a simple API implemented in AWS Lambda:
+
+```javascript
+"use strict";
+
+exports.handler = async (event) => {
+  // Lambda handler code
+  return {
+    body: `Hello World`,
+    statusCode: 200,
+  };
+};
+```
+
+```yaml
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: Lambda Function URL
+Resources:
+  FURLFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: app.handler
+      Runtime: nodejs20.x
+      Timeout: 3
+      ### If you want to use Function URLs
+      # FunctionUrlConfig:
+      #   AuthType: AWS_IAM
+      #   Cors:
+      #     AllowOrigins: ["*"]
+
+Outputs:
+  FunctionURLEndpoint:
+    Description: FURLFunction function name
+    Value: !GetAtt FURLFunctionUrl.FunctionUrl
+```
+
+### Use as a library
+
+You can call the API by following code:
+
+```go
+// initialize AWS SDK
+cfg, err := config.LoadDefaultConfig(context.Background())
+if err != nil {
+    panic(err)
+}
+svc := lambda.NewFromConfig(cfg)
+
+// register the lambda protocol
+t := &http.Transport{}
+t.RegisterProtocol("lambda", lambtrip.NewBufferedTransport(svc))
+c := &http.Client{Transport: t}
+
+// send a request to the lambda function
+resp, err := c.Get("lambda://function-name/foo/bar")
+if err != nil {
+    panic(err)
+}
+defer resp.Body.Close()
+```
+
+### Use function-url-local command
+
+function-url-local is a minimum clone of AWS Lambda Function URLs.
+
+```
+$ go install github.com/shogo82148/lambtrip/cmd/function-url-local@latest
+$ function-url-local function-name
+{"time":"2024-02-05T22:28:57.781792+09:00","level":"INFO","msg":"starting the server","addr":":8080"}
+```

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,31 @@
+package lambtrip_test
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	"github.com/shogo82148/lambtrip"
+)
+
+func Example() {
+	// initialize AWS SDK
+	cfg, err := config.LoadDefaultConfig(context.Background())
+	if err != nil {
+		panic(err)
+	}
+	svc := lambda.NewFromConfig(cfg)
+
+	// register the lambda protocol
+	t := &http.Transport{}
+	t.RegisterProtocol("lambda", lambtrip.NewBufferedTransport(svc))
+	c := &http.Client{Transport: t}
+
+	// send a request to the lambda function
+	resp, err := c.Get("lambda://function-name/foo/bar")
+	if err != nil {
+		panic(err)
+	}
+	defer resp.Body.Close()
+}

--- a/example_test.go
+++ b/example_test.go
@@ -10,19 +10,20 @@ import (
 )
 
 func Example() {
-	// initialize AWS SDK
+	// Initialize AWS SDK to create a service client for AWS Lambda.
 	cfg, err := config.LoadDefaultConfig(context.Background())
 	if err != nil {
 		panic(err)
 	}
 	svc := lambda.NewFromConfig(cfg)
 
-	// register the lambda protocol
+	// Create a new HTTP transport and register the "lambda" protocol with a custom transport handler.
 	t := &http.Transport{}
 	t.RegisterProtocol("lambda", lambtrip.NewBufferedTransport(svc))
+	// Create a new HTTP client using the custom transport to handle requests to Lambda functions.
 	c := &http.Client{Transport: t}
 
-	// send a request to the lambda function
+	// Make an HTTP GET request to a specific Lambda function using the custom "lambda://" protocol.
 	resp, err := c.Get("lambda://function-name/foo/bar")
 	if err != nil {
 		panic(err)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the `lambtrip` package, enabling AWS Lambda functions to be accessed as if they were HTTP endpoints, eliminating the need for AWS Lambda Function URLs, AWS Gateway, ALB, etc.
	- Added an example demonstrating how to integrate AWS Lambda functions with HTTP clients using a custom `lambda://` protocol handler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->