### PR TITLE
Refactor isBinary function to check for multiple Content-Encoding values

### DIFF
--- a/buffered.go
+++ b/buffered.go
@@ -231,10 +231,12 @@ func buildRequest(req *http.Request) (*request, error) {
 	}, nil
 }
 
-// assume text/*, application/json, application/javascript, application/xml, */*+json, */*+xml as text
+// assume text/*, application/json, application/javascript, application/xml, */*+json, */*+xml, etc. as text
 func isBinary(headers http.Header) bool {
 	contentEncoding := headers.Values("Content-Encoding")
 	if len(contentEncoding) > 0 {
+		// typically, gzip, deflate, br, etc.
+		// these compressed encodings are not text, they are binary.
 		return true
 	}
 
@@ -250,6 +252,7 @@ func isBinary(headers http.Header) bool {
 	}
 	mainType := mediaType[:i]
 
+	// common text mime types
 	if strings.EqualFold(mainType, "text") {
 		return false
 	}
@@ -266,6 +269,7 @@ func isBinary(headers http.Header) bool {
 		return false
 	}
 
+	// custom text mime types, such as application/*+json, application/*+xml
 	i = strings.LastIndex(mediaType, "+")
 	if i == -1 {
 		i = 0
@@ -280,6 +284,8 @@ func isBinary(headers http.Header) bool {
 	if strings.EqualFold(suffix, "+xml") {
 		return false
 	}
+
+	// assume it's binary
 	return true
 }
 

--- a/buffered.go
+++ b/buffered.go
@@ -233,8 +233,8 @@ func buildRequest(req *http.Request) (*request, error) {
 
 // assume text/*, application/json, application/javascript, application/xml, */*+json, */*+xml as text
 func isBinary(headers http.Header) bool {
-	contentEncoding := headers.Get("Content-Encoding")
-	if contentEncoding != "" && !strings.EqualFold(contentEncoding, "identity") {
+	contentEncoding := headers.Values("Content-Encoding")
+	if len(contentEncoding) > 0 {
 		return true
 	}
 

--- a/buffered_test.go
+++ b/buffered_test.go
@@ -203,15 +203,6 @@ func TestIsBinary(t *testing.T) {
 			want: true,
 		},
 
-		// text/html and not encoded
-		{
-			header: http.Header{
-				"Content-Type":     []string{"text/html; charset=utf-8"},
-				"Content-Encoding": []string{"identity"},
-			},
-			want: false,
-		},
-
 		// text/*
 		{
 			header: http.Header{


### PR DESCRIPTION
RFC 9110 says:

> Note that the coding named "identity" is reserved for its special role in [Accept-Encoding](https://www.rfc-editor.org/rfc/rfc9110#field.accept-encoding) and thus SHOULD NOT be included.

https://www.rfc-editor.org/rfc/rfc9110#field.content-encoding



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the accuracy in determining binary content by refining the logic based on `Content-Encoding` values in headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->