### PR TITLE
Supports lambda function qualifier by URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ if err != nil {
 defer resp.Body.Close()
 ```
 
+#### Specify the function qualifier
+
+You can specify the function qualifier by the URL.
+
+```go
+resp, err := c.Get("lambda://xxx@function-name/foo/bar")
+```
+
+`xxx` is the function qualifier (alias name or version number).
+
 ### Use function-url-local command
 
 function-url-local is a minimum clone of AWS Lambda Function URLs.

--- a/buffered.go
+++ b/buffered.go
@@ -145,10 +145,15 @@ func (t *BufferedTransport) RoundTrip(req *http.Request) (*http.Response, error)
 	}
 
 	// invoke the lambda
-	out, err := t.lambda.Invoke(ctx, &lambda.InvokeInput{
+	in := &lambda.InvokeInput{
 		FunctionName: aws.String(req.URL.Host),
 		Payload:      payload,
-	})
+	}
+	if req.URL.User != nil {
+		// lambda://alias@function
+		in.Qualifier = aws.String(req.URL.User.Username())
+	}
+	out, err := t.lambda.Invoke(ctx, in)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Hi!

Added specify the qualifier of lambda function by URL.

`lambda://xxx@function-name/foo/bar` calls the lambda function `function-name:xxx`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to specify a function qualifier in a URL for AWS Lambda interactions.
  - Updated documentation with a new example demonstrating this feature.

- **Tests**
  - Introduced tests to verify the behavior of `BufferedTransport` with and without a qualifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->